### PR TITLE
Fix power-up preservation on death

### DIFF
--- a/SpaceCombat/app/src/main/java/com/spacecombat/game/HealthHUD.java
+++ b/SpaceCombat/app/src/main/java/com/spacecombat/game/HealthHUD.java
@@ -34,10 +34,12 @@ public class HealthHUD extends Component
 			GUI.drawText("Game Over", 220, 400, 20, 20);
 			GUI.drawText("Play Again?", 220, 420, 20, 20);
 			
-			if (GUI.drawText("Yes", 200, 440, 20, 20))
-			{
-				LevelLoader.loadLevel(LevelLoader.getLastLevelLoaded(),true);
-			}
+                        if (GUI.drawText("Yes", 200, 440, 20, 20))
+                        {
+                                // Reload the level but preserve persistent objects
+                                // so the player's upgrades survive the restart
+                                LevelLoader.loadLevel(LevelLoader.getLastLevelLoaded(),false);
+                        }
 			
 			if (GUI.drawText("No", 240, 440, 20, 20))
 			{


### PR DESCRIPTION
## Summary
- restart the current level without clearing persistent objects when clicking "Yes" on the Game Over screen

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683bb1d34d6c8331a7f9c5a3b1f8c3e0