### PR TITLE
Switch from jcenter to Maven Central

### DIFF
--- a/SpaceCombat/build.gradle
+++ b/SpaceCombat/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
@@ -15,7 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }


### PR DESCRIPTION
## Summary
- replace deprecated `jcenter()` repository with `mavenCentral()`

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68634e2829248331abaefcd5edca260f