### PR TITLE
Update project to Gradle 8.1.1

### DIFF
--- a/SpaceCombat/app/build.gradle
+++ b/SpaceCombat/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 34
+    namespace "com.spacecombat"
     defaultConfig {
         applicationId "com.spacecombat"
-        minSdkVersion 10
-        targetSdkVersion 26
+        minSdkVersion 19
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }
@@ -17,14 +17,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     productFlavors {
     }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.appcompat:appcompat:1.6.1'
 }

--- a/SpaceCombat/build.gradle
+++ b/SpaceCombat/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:8.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/SpaceCombat/gradle/wrapper/gradle-wrapper.properties
+++ b/SpaceCombat/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip


### PR DESCRIPTION
## Summary
- bump Gradle wrapper to 8.1.1
- update Android Gradle plugin to 8.1.1
- update app module compileSdk and dependencies

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew assembleDebug --no-daemon` *(fails: Android SDK Platform 34 license not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_686493f3b6c48331b4299fc014447152