### PR TITLE
Fix Java incompatibility with updated Gradle wrapper

### DIFF
--- a/SpaceCombat/gradle/wrapper/gradle-wrapper.properties
+++ b/SpaceCombat/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip


### PR DESCRIPTION
## Summary
- update the Gradle wrapper distribution to version 8.5 so it works with JDK 21

## Testing
- `CI=1 bash SpaceCombat/gradlew --version --no-daemon --console=plain --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686496dc82c88331876cec193e9090a9