### PR TITLE
Fix manifest exported flag for Android 12+

### DIFF
--- a/SpaceCombat/app/src/main/AndroidManifest.xml
+++ b/SpaceCombat/app/src/main/AndroidManifest.xml
@@ -9,10 +9,11 @@
     	android:label="@string/app_name" 
     	android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
     	
-        <activity 
-        	android:name="com.spacecombat.Run"
-        	android:label="@string/app_name"
-        	android:screenOrientation="portrait">
+        <activity
+                android:name="com.spacecombat.Run"
+                android:label="@string/app_name"
+                android:screenOrientation="portrait"
+                android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- add required `android:exported` flag to the main `Run` activity

## Testing
- `bash gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b12ce46483318cdc8d2c36f4f617